### PR TITLE
feat: add signin page and setup auth

### DIFF
--- a/lib/config/app_routes.dart
+++ b/lib/config/app_routes.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
 
+import '../ui/signin/signin.dart';
+
 abstract class AppRoutes {
+  static const home = '/';
   static const signUp = '/signup';
+  static const signIn = '/signin';
+  static const profile = '/profile';
 
   static Route<void> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
+      case AppRoutes.signIn:
+        return SignInPage.route(settings);
       default:
         return _errorRoute();
     }

--- a/lib/data/repositories/auth_repository.dart
+++ b/lib/data/repositories/auth_repository.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;

--- a/lib/data/repositories/repositories.dart
+++ b/lib/data/repositories/repositories.dart
@@ -1,0 +1,2 @@
+export 'auth_repository.dart';
+export 'exceptions/http_error.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'config/config.dart';
+import 'data/repositories/repositories.dart';
+import 'ui/signin/signin.dart';
 
 void main() => runApp(const App());
 
@@ -9,12 +12,28 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'μGesCon',
-      theme: AppTheme.light,
-      initialRoute: AppRoutes.signUp,
-      onGenerateRoute: AppRoutes.onGenerateRoute,
+    return MultiRepositoryProvider(
+      providers: [
+        RepositoryProvider<AuthRepository>(
+          create: (context) => AuthRepository(),
+        ),
+      ],
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider<SignInBloc>(
+            create: (context) => SignInBloc(
+              authRepository: context.read<AuthRepository>(),
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          debugShowCheckedModeBanner: false,
+          title: 'μGesCon',
+          theme: AppTheme.light,
+          initialRoute: AppRoutes.signIn,
+          onGenerateRoute: AppRoutes.onGenerateRoute,
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/signin/signin.dart
+++ b/lib/ui/signin/signin.dart
@@ -1,0 +1,4 @@
+export 'signin_bloc.dart';
+export 'signin_event.dart';
+export 'signin_page.dart';
+export 'signin_state.dart';

--- a/lib/ui/signin/signin_bloc.dart
+++ b/lib/ui/signin/signin_bloc.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../data/repositories/repositories.dart';
+import 'signin_event.dart';
+import 'signin_state.dart';
+
+class SignInBloc extends Bloc<SignInEvent, SignInState> {
+  final AuthRepository authRepository;
+
+  SignInBloc({
+    required this.authRepository,
+  }) : super(Initial()) {
+    on<Submit>(_onSubmit);
+  }
+
+  void _onSubmit(Submit event, Emitter<SignInState> emit) async {
+    emit(Loading());
+
+    try {
+      final authModel = await authRepository.signIn({
+        'email': event.email,
+        'password': event.password,
+      });
+
+      emit(Loaded(user: authModel.user));
+    } on HttpError catch (e) {
+      emit(Failed(error: e.error));
+    }
+  }
+}

--- a/lib/ui/signin/signin_event.dart
+++ b/lib/ui/signin/signin_event.dart
@@ -1,0 +1,18 @@
+import 'package:equatable/equatable.dart';
+
+abstract class SignInEvent extends Equatable {
+  const SignInEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class Submit extends SignInEvent {
+  final String email;
+  final String password;
+
+  const Submit({
+    required this.email,
+    required this.password,
+  });
+}

--- a/lib/ui/signin/signin_page.dart
+++ b/lib/ui/signin/signin_page.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/svg.dart';
+
+import '../../config/config.dart';
+import 'signin_bloc.dart';
+import 'signin_event.dart';
+import 'signin_state.dart';
+
+class SignInPage extends StatefulWidget {
+  const SignInPage({super.key});
+
+  static Route<void> route(RouteSettings settings) {
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) => const SignInPage(),
+    );
+  }
+
+  @override
+  State<SignInPage> createState() => _SignInPageState();
+}
+
+class _SignInPageState extends State<SignInPage> {
+  late GlobalKey<FormState> _formKey;
+  late TextEditingController _ecEmail;
+  late TextEditingController _ecPassword;
+  late bool _hidePassword;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _formKey = GlobalKey<FormState>();
+    _ecEmail = TextEditingController();
+    _ecPassword = TextEditingController();
+    _hidePassword = true;
+  }
+
+  @override
+  void dispose() {
+    _ecEmail.dispose();
+    _ecPassword.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        body: Center(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16.0),
+                  child: SizedBox(
+                    height: 128,
+                    width: 128,
+                    child: SvgPicture.asset(AppAssets.signInImage),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16.0),
+                  child: Form(
+                    key: _formKey,
+                    child: BlocListener<SignInBloc, SignInState>(
+                      listener: (context, state) {
+                        if (state is Failed) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Credenciais inválidas'),
+                            ),
+                          );
+                        }
+
+                        if (state is Loaded) {
+                          Navigator.of(context).pushNamedAndRemoveUntil(
+                            AppRoutes.home,
+                            arguments: state.user,
+                            (_) => false,
+                          );
+                        }
+                      },
+                      child: BlocBuilder<SignInBloc, SignInState>(
+                        builder: (context, state) {
+                          return Column(
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: TextFormField(
+                                  readOnly: state is Loading ? true : false,
+                                  controller: _ecEmail,
+                                  keyboardType: TextInputType.emailAddress,
+                                  autovalidateMode:
+                                      AutovalidateMode.onUserInteraction,
+                                  decoration: const InputDecoration(
+                                    prefixIcon: Icon(Icons.email),
+                                    labelText: 'Email',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  validator: (text) {
+                                    if (text == null || text.trim().isEmpty) {
+                                      return 'Campo obrigatório';
+                                    }
+
+                                    if (!RegExp(r'.+@.+')
+                                        .hasMatch(text.trim())) {
+                                      return 'Email inválido';
+                                    }
+
+                                    return null;
+                                  },
+                                ),
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: TextFormField(
+                                  readOnly: state is Loading ? true : false,
+                                  controller: _ecPassword,
+                                  obscureText: _hidePassword,
+                                  keyboardType: TextInputType.visiblePassword,
+                                  autovalidateMode:
+                                      AutovalidateMode.onUserInteraction,
+                                  decoration: InputDecoration(
+                                    prefixIcon: const Icon(Icons.lock),
+                                    suffixIcon: IconButton(
+                                      onPressed: () => setState(() {
+                                        _hidePassword = !_hidePassword;
+                                      }),
+                                      icon: _hidePassword
+                                          ? const Icon(Icons.visibility)
+                                          : const Icon(Icons.visibility_off),
+                                    ),
+                                    labelText: 'Senha',
+                                    border: const OutlineInputBorder(),
+                                  ),
+                                  validator: (text) =>
+                                      text == null || text.trim().isEmpty
+                                          ? 'Campo obrigatório'
+                                          : null,
+                                ),
+                              ),
+                              state is Loading
+                                  ? Padding(
+                                      padding: const EdgeInsets.all(8.0),
+                                      child: SizedBox(
+                                        width:
+                                            MediaQuery.of(context).size.width,
+                                        height: 56,
+                                        child: const ElevatedButton(
+                                          onPressed: null,
+                                          child: SizedBox(
+                                            height: 28,
+                                            width: 28,
+                                            child: CircularProgressIndicator(),
+                                          ),
+                                        ),
+                                      ),
+                                    )
+                                  : Padding(
+                                      padding: const EdgeInsets.all(8.0),
+                                      child: SizedBox(
+                                        width:
+                                            MediaQuery.of(context).size.width,
+                                        height: 56,
+                                        child: ElevatedButton(
+                                          onPressed: () => context
+                                              .read<SignInBloc>()
+                                              .add(Submit(
+                                                email: _ecEmail.text,
+                                                password: _ecPassword.text,
+                                              )),
+                                          child: const SizedBox(
+                                            child: Text(
+                                              'ENTRAR',
+                                              style: TextStyle(fontSize: 18),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                mainAxisSize: MainAxisSize.max,
+                                children: [
+                                  const Text(
+                                    'Ainda não tem cadastro?',
+                                    style: TextStyle(
+                                      color: Colors.black38,
+                                      fontWeight: FontWeight.w400,
+                                      fontSize: 16,
+                                    ),
+                                  ),
+                                  TextButton(
+                                    child: Text(
+                                      'Cadastre-se',
+                                      style: TextStyle(
+                                        color: Theme.of(context).primaryColor,
+                                        fontWeight: FontWeight.bold,
+                                        fontSize: 16,
+                                      ),
+                                    ),
+                                    onPressed: () => Navigator.of(context)
+                                        .pushReplacementNamed(AppRoutes.signUp),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/signin/signin_state.dart
+++ b/lib/ui/signin/signin_state.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+
+import '../../data/models/models.dart';
+
+abstract class SignInState extends Equatable {
+  const SignInState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class Initial extends SignInState {}
+
+class Loading extends SignInState {}
+
+class Loaded extends SignInState {
+  final UserModel user;
+
+  const Loaded({required this.user});
+
+  @override
+  List<Object> get props => [user];
+}
+
+class Failed extends SignInState {
+  final String error;
+
+  const Failed({required this.error});
+
+  @override
+  List<Object> get props => [error];
+}


### PR DESCRIPTION
# description

add sign in page and setup authentication

## acceptance criteria
* must be set as sign in page as initial page
* must use `bloc` as state management

## linked issues
- closes #8 
- closes #9 